### PR TITLE
Fix swash host subcommand flag parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ __pycache__/
 # Nix
 result
 
-# Test artifacts
-test
+# Test artifacts (temp files, not the test/ directory)
+*.test
 *.o
 

--- a/cmd/mini-systemd/journal_socket.go
+++ b/cmd/mini-systemd/journal_socket.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// JournalSocketListener listens on a Unix datagram socket for journal messages
+// using the same protocol as systemd-journald.
+type JournalSocketListener struct {
+	conn    *net.UnixConn
+	path    string
+	journal *JournalService
+}
+
+// NewJournalSocketListener creates a socket listener at the given path.
+// The socket accepts messages in journald's native protocol format.
+func NewJournalSocketListener(socketPath string, journal *JournalService) (*JournalSocketListener, error) {
+	// Ensure directory exists
+	dir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create socket directory: %w", err)
+	}
+
+	// Remove existing socket
+	os.Remove(socketPath)
+
+	addr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+	conn, err := net.ListenUnixgram("unixgram", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen on socket: %w", err)
+	}
+
+	// Make socket world-writable so any process can log
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+
+	return &JournalSocketListener{
+		conn:    conn,
+		path:    socketPath,
+		journal: journal,
+	}, nil
+}
+
+// Run starts the socket listener loop. Call this in a goroutine.
+func (l *JournalSocketListener) Run() {
+	buf := make([]byte, 64*1024) // journald uses 64KB max
+
+	for {
+		n, _, err := l.conn.ReadFromUnix(buf)
+		if err != nil {
+			// Socket closed
+			if strings.Contains(err.Error(), "use of closed") {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "journal socket read error: %v\n", err)
+			continue
+		}
+
+		fields, err := parseJournalMessage(buf[:n])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "journal socket parse error: %v\n", err)
+			continue
+		}
+
+		// Extract MESSAGE and send to journal
+		message := fields["MESSAGE"]
+		delete(fields, "MESSAGE")
+		delete(fields, "PRIORITY") // We don't use priority levels
+
+		l.journal.Send(message, fields)
+	}
+}
+
+// Close stops the listener and removes the socket.
+func (l *JournalSocketListener) Close() error {
+	err := l.conn.Close()
+	os.Remove(l.path)
+	return err
+}
+
+// parseJournalMessage parses a message in journald's socket protocol.
+// Format is a series of fields, each either:
+//   - NAME=value\n (simple case)
+//   - NAME\n<8-byte LE length><data>\n (binary/multiline case)
+func parseJournalMessage(data []byte) (map[string]string, error) {
+	fields := make(map[string]string)
+
+	for len(data) > 0 {
+		// Find the next newline or equals sign
+		eqIdx := bytes.IndexByte(data, '=')
+		nlIdx := bytes.IndexByte(data, '\n')
+
+		if eqIdx == -1 && nlIdx == -1 {
+			// Malformed - no delimiter found
+			break
+		}
+
+		if eqIdx != -1 && (nlIdx == -1 || eqIdx < nlIdx) {
+			// Simple format: NAME=value\n
+			name := string(data[:eqIdx])
+			data = data[eqIdx+1:]
+
+			// Find end of value
+			endIdx := bytes.IndexByte(data, '\n')
+			if endIdx == -1 {
+				// Value extends to end
+				fields[name] = string(data)
+				break
+			}
+
+			fields[name] = string(data[:endIdx])
+			data = data[endIdx+1:]
+		} else {
+			// Binary format: NAME\n<8-byte length><data>\n
+			name := string(data[:nlIdx])
+			data = data[nlIdx+1:]
+
+			if len(data) < 8 {
+				return nil, fmt.Errorf("truncated length field for %s", name)
+			}
+
+			length := binary.LittleEndian.Uint64(data[:8])
+			data = data[8:]
+
+			if uint64(len(data)) < length {
+				return nil, fmt.Errorf("truncated value for %s", name)
+			}
+
+			fields[name] = string(data[:length])
+			data = data[length:]
+
+			// Skip trailing newline if present
+			if len(data) > 0 && data[0] == '\n' {
+				data = data[1:]
+			}
+		}
+	}
+
+	return fields, nil
+}

--- a/cmd/swash/main.go
+++ b/cmd/swash/main.go
@@ -24,6 +24,13 @@ import (
 )
 
 func main() {
+	// Handle "host" subcommand before flag parsing, since it has its own flags
+	// that pflag doesn't know about (--session, --command-json)
+	if len(os.Args) >= 2 && os.Args[1] == "host" {
+		cmdHost()
+		return
+	}
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `swash - Interactive process sessions over D-Bus
 

--- a/internal/swash/server.go
+++ b/internal/swash/server.go
@@ -86,11 +86,13 @@ func (s *SwashService) Kill() (string, *dbus.Error) {
 }
 
 // RunServer runs the D-Bus server for a session.
+// Called as: swash host --session ID --command-json [...]
 func RunServer() error {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	sessionIDFlag := fs.String("session", "", "Session ID")
 	commandJSONFlag := fs.String("command-json", "", "Command as JSON array")
-	fs.Parse(os.Args[1:])
+	// Skip "swash" (index 0) and "host" (index 1) to get to the flags
+	fs.Parse(os.Args[2:])
 
 	if *sessionIDFlag == "" || *commandJSONFlag == "" {
 		return fmt.Errorf("missing required flags")

--- a/pkg/journalfile/journal.go
+++ b/pkg/journalfile/journal.go
@@ -473,6 +473,9 @@ func (jf *File) writeEntryArray() error {
 	jf.header.TailEntryArrayOffset = uint32(offset)
 	jf.header.TailEntryArrayNEntries = uint32(nItems)
 
+	// Clear items so subsequent flushes only include new entries
+	jf.entryArrayItems = jf.entryArrayItems[:0]
+
 	return nil
 }
 

--- a/pkg/journalfile/journal.go
+++ b/pkg/journalfile/journal.go
@@ -379,6 +379,36 @@ func (jf *File) appendEntryObject(realtime, monotonic, xorHash uint64, items []E
 	return jf.syncHeader()
 }
 
+// Sync flushes pending writes and sets state to OFFLINE so external readers
+// (like journalctl) can access the file. The file remains open for further writes.
+// This mimics journald's SyncIntervalSec behavior.
+func (jf *File) Sync() error {
+	jf.mu.Lock()
+	defer jf.mu.Unlock()
+
+	// Write entry array if we have entries
+	if len(jf.entryArrayItems) > 0 {
+		if err := jf.writeEntryArray(); err != nil {
+			return err
+		}
+	}
+
+	// Update arena size
+	endPos, err := jf.f.Seek(0, 2)
+	if err == nil {
+		jf.header.ArenaSize = uint64(endPos) - HeaderSize
+	}
+
+	// Set offline so readers can access
+	jf.header.State = StateOffline
+	if err := jf.syncHeader(); err != nil {
+		return err
+	}
+
+	// Fsync to ensure data is on disk
+	return jf.f.Sync()
+}
+
 // Close closes the journal file
 func (jf *File) Close() error {
 	jf.mu.Lock()

--- a/pkg/journalfile/lookup3.go
+++ b/pkg/journalfile/lookup3.go
@@ -67,14 +67,11 @@ func JenkinsHashLittle2(data []byte) (pc, pb uint32) {
 	}
 
 	// Handle the last (probably partial) block
+	// Based on lookup3.c switch statement - cases fall through in groups
 	switch len(data) {
 	case 12:
 		c += uint32(data[8]) | uint32(data[9])<<8 | uint32(data[10])<<16 | uint32(data[11])<<24
-		fallthrough
-	case 8:
 		b += uint32(data[4]) | uint32(data[5])<<8 | uint32(data[6])<<16 | uint32(data[7])<<24
-		fallthrough
-	case 4:
 		a += uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
 	case 11:
 		c += uint32(data[10]) << 16
@@ -84,7 +81,12 @@ func JenkinsHashLittle2(data []byte) (pc, pb uint32) {
 		fallthrough
 	case 9:
 		c += uint32(data[8])
-		fallthrough
+		// Fall through to case 8's logic (not case 7!)
+		b += uint32(data[4]) | uint32(data[5])<<8 | uint32(data[6])<<16 | uint32(data[7])<<24
+		a += uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
+	case 8:
+		b += uint32(data[4]) | uint32(data[5])<<8 | uint32(data[6])<<16 | uint32(data[7])<<24
+		a += uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
 	case 7:
 		b += uint32(data[6]) << 16
 		fallthrough
@@ -93,6 +95,9 @@ func JenkinsHashLittle2(data []byte) (pc, pb uint32) {
 		fallthrough
 	case 5:
 		b += uint32(data[4])
+		// Fall through to case 4's logic
+		a += uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
+	case 4:
 		a += uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
 	case 3:
 		a += uint32(data[2]) << 16

--- a/test/integration/harness.go
+++ b/test/integration/harness.go
@@ -1,0 +1,128 @@
+// Package integration provides a test harness for running swash with mini-systemd.
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// TestEnv represents a test environment with dbus-daemon and mini-systemd.
+type TestEnv struct {
+	// Paths
+	TempDir    string
+	SocketPath string
+	JournalDir string
+
+	// Processes
+	dbusDaemon  *exec.Cmd
+	miniSystemd *exec.Cmd
+
+	// Environment variable for connecting to this bus
+	BusAddress string
+}
+
+// NewTestEnv creates a new test environment.
+func NewTestEnv() (*TestEnv, error) {
+	tmpDir, err := os.MkdirTemp("", "swash-test-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	return &TestEnv{
+		TempDir:    tmpDir,
+		SocketPath: filepath.Join(tmpDir, "bus.sock"),
+		JournalDir: filepath.Join(tmpDir, "journal"),
+	}, nil
+}
+
+// Start launches dbus-daemon and mini-systemd.
+func (e *TestEnv) Start(ctx context.Context) error {
+	// Create journal directory
+	if err := os.MkdirAll(e.JournalDir, 0750); err != nil {
+		return fmt.Errorf("create journal dir: %w", err)
+	}
+
+	// Start dbus-daemon
+	e.dbusDaemon = exec.CommandContext(ctx,
+		"dbus-daemon",
+		"--session",
+		"--nofork",
+		"--address=unix:path="+e.SocketPath,
+		"--print-address",
+	)
+	e.dbusDaemon.Stderr = os.Stderr
+
+	if err := e.dbusDaemon.Start(); err != nil {
+		return fmt.Errorf("start dbus-daemon: %w", err)
+	}
+
+	e.BusAddress = "unix:path=" + e.SocketPath
+
+	// Wait for socket to appear
+	for i := 0; i < 50; i++ {
+		if _, err := os.Stat(e.SocketPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Start mini-systemd
+	e.miniSystemd = exec.CommandContext(ctx,
+		"mini-systemd",
+		"--journal-dir="+e.JournalDir,
+	)
+	e.miniSystemd.Env = append(os.Environ(), "DBUS_SESSION_BUS_ADDRESS="+e.BusAddress)
+	e.miniSystemd.Stderr = os.Stderr
+
+	if err := e.miniSystemd.Start(); err != nil {
+		e.dbusDaemon.Process.Kill()
+		return fmt.Errorf("start mini-systemd: %w", err)
+	}
+
+	// Wait for mini-systemd to register on the bus
+	time.Sleep(100 * time.Millisecond)
+
+	return nil
+}
+
+// Stop shuts down mini-systemd and dbus-daemon.
+func (e *TestEnv) Stop() error {
+	var errs []error
+
+	if e.miniSystemd != nil && e.miniSystemd.Process != nil {
+		e.miniSystemd.Process.Signal(os.Interrupt)
+		e.miniSystemd.Wait()
+	}
+
+	if e.dbusDaemon != nil && e.dbusDaemon.Process != nil {
+		e.dbusDaemon.Process.Kill()
+		e.dbusDaemon.Wait()
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("stop errors: %v", errs)
+	}
+	return nil
+}
+
+// Cleanup removes the temp directory.
+func (e *TestEnv) Cleanup() error {
+	return os.RemoveAll(e.TempDir)
+}
+
+// Env returns the environment variables needed to connect to this test environment.
+func (e *TestEnv) Env() []string {
+	return append(os.Environ(), "DBUS_SESSION_BUS_ADDRESS="+e.BusAddress)
+}
+
+// RunSwash runs the swash binary with the given arguments.
+func (e *TestEnv) RunSwash(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "swash", args...)
+	cmd.Env = e.Env()
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}

--- a/test/integration/swash_test.go
+++ b/test/integration/swash_test.go
@@ -2,7 +2,9 @@ package integration
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +132,150 @@ func TestSwashRunEcho(t *testing.T) {
 		t.Logf("Warning: GetEntries failed: %v", err)
 	} else {
 		t.Logf("Journal entries:\n%s", journalOut)
+	}
+}
+
+// TestTaskOutputCapture tests that task stdout/stderr is captured in the journal.
+// This test is expected to FAIL until we implement proper output capture.
+//
+// The issue: swash host reads task output via pipes and calls journal.Send(),
+// which writes to /run/systemd/journal/socket (real journald). In our test
+// environment with mini-systemd, there's no real journald, so output is lost.
+//
+// To fix: swash host should write output to mini-systemd's journal via D-Bus
+// when running under mini-systemd (detect via checking if systemd1 bus name
+// is mini-systemd, or via environment variable).
+func TestTaskOutputCapture(t *testing.T) {
+	ensureBinaries(t)
+
+	env, err := NewTestEnv()
+	if err != nil {
+		t.Fatalf("NewTestEnv: %v", err)
+	}
+	defer env.Cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := env.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer env.Stop()
+
+	// Run a command that produces distinctive output
+	const testMessage = "UNIQUE_TEST_OUTPUT_12345"
+	output, err := env.RunSwash(ctx, "run", "echo", testMessage)
+	if err != nil {
+		t.Fatalf("swash run failed: %v\n%s", err, output)
+	}
+
+	// Extract session ID
+	parts := strings.Fields(output)
+	if len(parts) < 1 {
+		t.Fatalf("unexpected output format: %s", output)
+	}
+	sessionID := parts[0]
+	t.Logf("Session ID: %s", sessionID)
+
+	// Wait for task to complete and output to be captured
+	time.Sleep(1 * time.Second)
+
+	// Query mini-systemd's journal for the output
+	cmd := exec.CommandContext(ctx, "dbus-send",
+		"--print-reply",
+		"--dest=org.freedesktop.systemd1",
+		"/org/freedesktop/systemd1",
+		"sh.swa.MiniSystemd.Journal.GetEntries",
+	)
+	cmd.Env = env.Env()
+	journalOut, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("GetEntries failed: %v\n%s", err, journalOut)
+	}
+	t.Logf("Journal entries:\n%s", journalOut)
+
+	// The test: task output should appear in mini-systemd's journal
+	if !strings.Contains(string(journalOut), testMessage) {
+		t.Errorf("Task output not captured in journal!\n"+
+			"Expected to find %q in journal entries.\n"+
+			"This fails because swash host uses journal.Send() which writes to\n"+
+			"/run/systemd/journal/socket (real journald), not mini-systemd's D-Bus journal.\n"+
+			"Journal contents:\n%s", testMessage, journalOut)
+	}
+}
+
+// TestNewlineSplitting verifies that multi-line output is split into separate
+// journal entries (one per line), matching systemd/journald semantics.
+//
+// From systemd docs: "When stdout/stderr is connected to the journal, output is
+// logged line by line. Each newline terminates a journal entry."
+//
+// Note: This test also requires fixing the output capture issue first.
+func TestNewlineSplitting(t *testing.T) {
+	ensureBinaries(t)
+
+	env, err := NewTestEnv()
+	if err != nil {
+		t.Fatalf("NewTestEnv: %v", err)
+	}
+	defer env.Cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := env.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer env.Stop()
+
+	// Create a test script that produces multiple lines
+	// This avoids the pflag issue with dash-prefixed arguments
+	testScript := filepath.Join(env.TempDir, "multiline.sh")
+	if err := os.WriteFile(testScript, []byte("#!/bin/sh\necho LINE_ONE\necho LINE_TWO\necho LINE_THREE\n"), 0755); err != nil {
+		t.Fatalf("creating test script: %v", err)
+	}
+
+	output, err := env.RunSwash(ctx, "run", testScript)
+	if err != nil {
+		t.Fatalf("swash run failed: %v\n%s", err, output)
+	}
+
+	// Wait for output to be captured
+	time.Sleep(1 * time.Second)
+
+	// Query journal
+	cmd := exec.CommandContext(ctx, "dbus-send",
+		"--print-reply",
+		"--dest=org.freedesktop.systemd1",
+		"/org/freedesktop/systemd1",
+		"sh.swa.MiniSystemd.Journal.GetEntries",
+	)
+	cmd.Env = env.Env()
+	journalOut, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("GetEntries failed: %v\n%s", err, journalOut)
+	}
+	t.Logf("Journal entries:\n%s", journalOut)
+
+	journalStr := string(journalOut)
+
+	// Each line should appear as a separate MESSAGE in the journal
+	// (not concatenated as "LINE_ONE\nLINE_TWO\nLINE_THREE")
+	lines := []string{"LINE_ONE", "LINE_TWO", "LINE_THREE"}
+	for _, line := range lines {
+		if !strings.Contains(journalStr, line) {
+			t.Errorf("Expected line %q not found in journal.\n"+
+				"This test requires output capture to work first.\n"+
+				"Journal contents:\n%s", line, journalStr)
+		}
+	}
+
+	// Verify lines are NOT concatenated (they should be separate entries)
+	if strings.Contains(journalStr, "LINE_ONE\\nLINE_TWO") ||
+		strings.Contains(journalStr, "LINE_ONELINE_TWO") {
+		t.Errorf("Lines appear concatenated instead of split into separate entries.\n"+
+			"systemd/journald splits stdout on newlines, each line becomes one entry.\n"+
+			"Journal contents:\n%s", journalStr)
 	}
 }
 

--- a/test/integration/swash_test.go
+++ b/test/integration/swash_test.go
@@ -1,0 +1,173 @@
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ensureBinaries builds swash and mini-systemd if needed
+func ensureBinaries(t *testing.T) {
+	t.Helper()
+
+	// Check if binaries exist in PATH or build them
+	if _, err := exec.LookPath("swash"); err != nil {
+		t.Log("Building swash...")
+		cmd := exec.Command("go", "build", "-o", "/tmp/bin/swash", "./cmd/swash/")
+		cmd.Dir = "../.."
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to build swash: %v\n%s", err, out)
+		}
+	}
+
+	if _, err := exec.LookPath("mini-systemd"); err != nil {
+		t.Log("Building mini-systemd...")
+		cmd := exec.Command("go", "build", "-o", "/tmp/bin/mini-systemd", "./cmd/mini-systemd/")
+		cmd.Dir = "../.."
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to build mini-systemd: %v\n%s", err, out)
+		}
+	}
+}
+
+func TestSwashJournalWrite(t *testing.T) {
+	ensureBinaries(t)
+
+	env, err := NewTestEnv()
+	if err != nil {
+		t.Fatalf("NewTestEnv: %v", err)
+	}
+	defer env.Cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := env.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer env.Stop()
+
+	// Test: write to journal via D-Bus
+	cmd := exec.CommandContext(ctx, "dbus-send",
+		"--print-reply",
+		"--dest=org.freedesktop.systemd1",
+		"/org/freedesktop/systemd1",
+		"sh.swa.MiniSystemd.Journal.Send",
+		"string:Test message from Go test",
+		"dict:string:string:TEST_KEY,test_value",
+	)
+	cmd.Env = env.Env()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dbus-send failed: %v\n%s", err, out)
+	}
+
+	// Verify: read with journalctl
+	cmd = exec.CommandContext(ctx, "journalctl",
+		"--file="+env.JournalDir+"/*.journal",
+		"-o", "short",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("journalctl failed: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "Test message from Go test") {
+		t.Errorf("expected message not found in journal output:\n%s", out)
+	}
+}
+
+func TestSwashRunEcho(t *testing.T) {
+	ensureBinaries(t)
+
+	env, err := NewTestEnv()
+	if err != nil {
+		t.Fatalf("NewTestEnv: %v", err)
+	}
+	defer env.Cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := env.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer env.Stop()
+
+	// Run swash
+	output, err := env.RunSwash(ctx, "run", "echo", "hello from test")
+	if err != nil {
+		t.Fatalf("swash run failed: %v\n%s", err, output)
+	}
+
+	// Should print session ID
+	if !strings.Contains(output, "started") {
+		t.Errorf("expected 'started' in output, got: %s", output)
+	}
+
+	// Extract session ID (format: "XXXXXX started")
+	parts := strings.Fields(output)
+	if len(parts) < 1 {
+		t.Fatalf("unexpected output format: %s", output)
+	}
+	sessionID := parts[0]
+	t.Logf("Session ID: %s", sessionID)
+
+	// Wait a moment for the process to complete
+	time.Sleep(500 * time.Millisecond)
+
+	// Check journal for output (via D-Bus interface since file might still be locked)
+	cmd := exec.CommandContext(ctx, "dbus-send",
+		"--print-reply",
+		"--dest=org.freedesktop.systemd1",
+		"/org/freedesktop/systemd1",
+		"sh.swa.MiniSystemd.Journal.GetEntries",
+	)
+	cmd.Env = env.Env()
+	journalOut, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Warning: GetEntries failed: %v", err)
+	} else {
+		t.Logf("Journal entries:\n%s", journalOut)
+	}
+}
+
+func TestEnvStartStop(t *testing.T) {
+	ensureBinaries(t)
+
+	env, err := NewTestEnv()
+	if err != nil {
+		t.Fatalf("NewTestEnv: %v", err)
+	}
+	defer env.Cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := env.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Verify dbus-daemon is accessible
+	cmd := exec.CommandContext(ctx, "dbus-send",
+		"--print-reply",
+		"--dest=org.freedesktop.DBus",
+		"/org/freedesktop/DBus",
+		"org.freedesktop.DBus.ListNames",
+	)
+	cmd.Env = env.Env()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dbus-send failed: %v\n%s", err, out)
+	}
+
+	// Should have systemd1 registered
+	if !strings.Contains(string(out), "org.freedesktop.systemd1") {
+		t.Errorf("expected org.freedesktop.systemd1 in bus names:\n%s", out)
+	}
+
+	if err := env.Stop(); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+}


### PR DESCRIPTION
Two issues were preventing `swash host` from parsing its flags correctly:

1. main.go's pflag.Parse() was seeing --session and --command-json as
   unknown flags before the "host" subcommand could be dispatched. Fix
   by handling "host" before calling flag.Parse().

2. server.go's RunServer() was parsing os.Args[1:] which starts with
   "host", causing the standard flag package to stop at the first
   non-flag argument. Fix by parsing os.Args[2:] to skip both the
   binary name and "host" subcommand.

These fixes were discovered while testing swash with mini-systemd on
a private D-Bus session bus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a journald-compatible socket listener and eager journal file syncing, fixes `swash host` flag parsing, and introduces an integration test harness with tests.
> 
> - **mini-systemd**:
>   - **Journal socket**: New `JournalSocketListener` (`cmd/mini-systemd/journal_socket.go`) to accept journald-native UDPGRAM messages and forward to `JournalService`.
>   - **Main**: New `--journal-socket` flag and listener startup in `cmd/mini-systemd/main.go`.
>   - **Journal service**: After appends, call `journalFile.Sync()` in `Send` and `AddFromUnit` to make entries visible to external readers.
> - **Journal file**:
>   - **Sync API**: New `(*File).Sync()` to flush, update header/arena, set `StateOffline`, and fsync (`pkg/journalfile/journal.go`).
> - **CLI (`swash`)**:
>   - **Flag parsing fix**: Handle `host` subcommand before `pflag.Parse()` in `cmd/swash/main.go`; parse `os.Args[2:]` in `internal/swash/server.go`.
> - **Hashing**:
>   - Fix `lookup3` tail-case fallthrough logic for correct hashing (`pkg/journalfile/lookup3.go`).
> - **Tests**:
>   - Add integration harness (`test/integration/harness.go`) and tests (`test/integration/swash_test.go`) for journal write, session run, output capture, and newline splitting.
> - **Misc**:
>   - `.gitignore`: ignore `*.test` artifacts (not entire `test/` dir).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5df89c49c72d5f2c0b169f724e1cbe6523cc9422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->