### PR TITLE
Fix syntax error: remove stray 'go' before package declaration

### DIFF
--- a/cmd/mini-systemd/journal.go
+++ b/cmd/mini-systemd/journal.go
@@ -1,4 +1,3 @@
-go
 package main
 
 import (


### PR DESCRIPTION
The previous commit accidentally introduced a stray 'go' on line 1
of journal.go, which caused build failures.