### PR TITLE
Add multi-client TTY attach with smart terminal size handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mbrock/swash
 
-go 1.25.5
+go 1.24.7
 
 require (
 	github.com/coreos/go-systemd/v22 v22.6.0


### PR DESCRIPTION
Implements GNU screen-inspired multi-client attach support:

- First client to attach sets the terminal size
- Subsequent clients must have terminal >= master size
- Clients with too-small terminals are rejected with friendly error
- When all clients disconnect, next attach can resize again

Features:
- Box-drawing border (┌─┐│└┘) when local terminal is larger than remote
- Session info (ID, dimensions) displayed in border
- SIGWINCH handling to redraw border on terminal resize
- All clients receive broadcast of PTY output

API changes:
- Attach() now takes clientRows/clientCols and returns clientID
- Detach() now takes clientID parameter
- New GetAttachedClients() method for introspection